### PR TITLE
Add SCMP's rss feed.

### DIFF
--- a/scraping/db_connector.py
+++ b/scraping/db_connector.py
@@ -5,7 +5,7 @@ import json
 # ['nid', 'title', 'description', 'author', 'url', 'content', 'urlToImage', 'publishedAt', 'addedOn', 'siteName', 'language', 'status']
 
 mydb = None
-TEST_TABLE_NAME = "TABLE_NAME"
+TEST_TABLE_NAME = "newsapi_en"
 PROD_TABLE_NAME = "newsapi_n"
 
 
@@ -40,7 +40,7 @@ def select():
 def insert(data_dict, target_table="test"):
     table_name = PROD_TABLE_NAME if target_table == "prod" else TEST_TABLE_NAME
     mycursor = mydb.cursor()
-    sql = "INSERT INTO {} (title, description, author, url, content, urlToImage, publishedAt, addedOn, siteName, language, status) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
+    sql = "INSERT INTO {} (title, description, author, url, content, urlToImage, publishedAt, addedOn, siteName, language, status) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) ON DUPLICATE KEY UPDATE title = %s, description = %s, author = %s, content = %s, urlToImage = %s, publishedAt = %s, addedOn = %s, siteName = %s, language = %s".format(
         table_name
     )
     val = (
@@ -54,7 +54,16 @@ def insert(data_dict, target_table="test"):
         data_dict["addedOn"],
         data_dict["siteName"],
         data_dict["language"],
-        "1" # Status
+        1, # Status
+        data_dict["title"],
+        data_dict["description"],
+        data_dict["author"],
+        data_dict["content"],
+        data_dict["urlToImage"],
+        data_dict["publishedAt"],
+        data_dict["addedOn"],
+        data_dict["siteName"],
+        data_dict["language"]
     )
     print("SQL query: ", sql)
     try:

--- a/scraping/scrape_rss.py
+++ b/scraping/scrape_rss.py
@@ -69,6 +69,10 @@ https://www.channelnewsasia.com/googlenews/cna_news_sitemap.xml
 NEWS_URLs = {
     "en": [
         (
+            "https://www.scmp.com/rss/318208/feed",
+            {"title": "title", "description": "description", "url": "link",},
+        ),
+        (
             "https://www.theage.com.au/rss/feed.xml",
             {"title": "title", "description": "description", "url": "link",},
         ),

--- a/scraping/scrape_rss.py
+++ b/scraping/scrape_rss.py
@@ -53,8 +53,8 @@ import db_connector
 """
 https://www.theage.com.au/rss/feed.xml
 https://www.theage.com.au/rss/world.xml
-http://www.heraldsun.com.au/news/breaking-news/rss
-http://www.heraldsun.com.au/rss
+# http://www.heraldsun.com.au/news/breaking-news/rss
+# http://www.heraldsun.com.au/rss
 https://www.news.com.au/content-feeds/latest-news-world/
 https://www.news.com.au/content-feeds/latest-news-national/
 http://www.dailytelegraph.com.au/news/breaking-news/rss
@@ -76,14 +76,16 @@ NEWS_URLs = {
             "https://www.theage.com.au/rss/world.xml",
             {"title": "title", "description": "description", "url": "link",},
         ),
-        (
-            "http://www.heraldsun.com.au/news/breaking-news/rss",
-            {"title": "title", "description": "description", "url": "link",},
-        ),
-        (
-            "http://www.heraldsun.com.au/rss",
-            {"title": "title", "description": "description", "url": "link",},
-        ),
+# Remove heraldsun rss to prevent scraping the same content as other rss
+# > as it's a smaller newspaper that is likely syndicating news from bigger news        
+#         (
+#             "http://www.heraldsun.com.au/news/breaking-news/rss",
+#             {"title": "title", "description": "description", "url": "link",},
+#         ),
+#         (
+#             "http://www.heraldsun.com.au/rss",
+#             {"title": "title", "description": "description", "url": "link",},
+#         ),
         (
             "https://www.news.com.au/content-feeds/latest-news-world/",
             {"title": "title", "description": "description", "url": "link",},


### PR DESCRIPTION
Tested.

Sample,

`{"title": "China coronavirus: Hong Kong nurses call in sick in protest at government refusal to close borders", "url": "https://www.scmp.com/news/hong-kong/health-environment/article/3048135/china-coronavirus-hong-kong-nurses-call-sick", "addedOn": "2020-02-03 16:35:04", "description": "Some 90 nurses take day off in protest at administration\u2019s response to coronavirus, as 3,000 medical staff sign petition backing strike action next week.", "language": "en", "siteName": "scmp.com", "author": "Chan Ho-Him", "publishedAt": "2020-01-29 15:43:29", "content": "Chan Ho-him\n\nChan Ho-him is a reporter for the Hong Kong desk focused on covering education policies. He joined the Post in 2019. Prior to that, he was an investigative reporter at Ming Pao.", "urlToImage": "https://cdn.i-scmp.com/sites/default/files/styles/og_image_scmp_generic/public/d8/images/methode/2020/01/30/a15ac34e-42aa-11ea-9fd9-ecfbb38a9743_image_hires_082106.jpg?itok=I-m8ZzIp&v=1580343672"}
`