### PR TITLE
Aggregate implementation for scrape_twitter.py

### DIFF
--- a/scraping/ScrapeBingCovid/scrape_bing.py
+++ b/scraping/ScrapeBingCovid/scrape_bing.py
@@ -69,3 +69,4 @@ if __name__ == "__main__":
             )
             logging.debug("Inserting state data: {}".format(currentState.__dict__))
             db_bingcovid.insert(currentState.__dict__, target_table=DB_TABLE)
+            

--- a/scraping/ScrapeBingCovid/scrape_bing.py
+++ b/scraping/ScrapeBingCovid/scrape_bing.py
@@ -1,10 +1,14 @@
+#!/usr/bin/env python3
+#
+# -*- coding: utf-8 -*-
+#
+# Author(s):
+#   - samueljklee@gmail.com
+#
 
 import sys
 import os
 import logging
-
-from datetime import datetime
-from dateutil import parser
 
 # Connect to db_connector from parent directory
 PARENT_DIR = ".."
@@ -21,81 +25,15 @@ API_URL = "https://bing.com/covid/data"
 # ScrapeRss helper function
 from ScrapeRss.helpers import get_seed_page
 
-#This class acts as the aggregate root
-#It allows entry to specific data points from sublasses within the same domain of BingCovidData
-class BingCovidData: 
-    def __init__(self,  posted_date=datetime.utcnow()):
-    self.posted_date = posted_date
-    self.worlddata = self.WorldData()    
-
-    #This subclass contains enities specifically regarding the whole world
-    class World:
-        def __init__(
-            self,
-            confirmed = None,
-            deaths = None,
-            recovered = None,
-            posted_date=datetime.utcnow()
-        ):
-            self.confirmed = confirmed
-            self.deaths = deaths
-            self.recovered = recovered
-            self.posted_date = posted_date
-
-    #This subclass contains enities specifically regarding specific countries
-    class Country:
-        def __init__(
-            self, 
-            confirmed = None,
-            deaths = None,
-            recovered = None,
-            last_update = None,
-            lat = None,
-            lng = None,
-            country = None,
-            posted_date=datetime.utcnow()
-        ):
-            self.confirmed = confirmed
-            self.deaths = deaths
-            self.recovered = recovered
-            self.last_update = last_update
-            self.lat = lat
-            self.lng = lng
-            self.country = country
-            self.posted_date = posted_date
-
-    #This subclass contains enities specifically regarding specific states
-    class State:
-          def __init__(
-            self, 
-            confirmed = None,
-            deaths = None,
-            recovered = None,
-            last_update = None,
-            lat = None,
-            lng = None,
-            country = None,
-            state = None,
-            posted_date=datetime.utcnow()
-          ):
-            self.confirmed = confirmed
-            self.deaths = deaths
-            self.recovered = recovered
-            self.last_update = last_update
-            self.lat = lat
-            self.lng = lng
-            self.country = country
-            self.state = state
-            self.posted_date = posted_date       
-
+# BingCovid
+from ScrapeBingCovid.BingCovid import BingCovid
 
 if __name__ == "__main__":
     db_bingcovid.connect()
     res = get_seed_page(API_URL).json()
 
-    # Whole world
-    #Instead of refrencing BingCovid, data pertaining to the whole world is refrenced through BingCovidData.World
-    wholeWorld = BingCovidData.World(
+    # whole world
+    wholeWorld = BingCovid(
         confirmed=res["totalConfirmed"],
         deaths=res["totalDeaths"],
         recovered=res["totalRecovered"],
@@ -105,8 +43,7 @@ if __name__ == "__main__":
 
     # Countries
     for countryData in res["areas"]:
-        #Instead of refrencing BingCovid, data pertaining to a specific country is refrenced through BingCovidData.Country
-        currentCountry = BingCovidData.Country(
+        currentCountry = BingCovid(
             confirmed=countryData["totalConfirmed"],
             deaths=countryData["totalDeaths"],
             recovered=countryData["totalRecovered"],
@@ -120,8 +57,7 @@ if __name__ == "__main__":
 
         # States
         for stateData in countryData["areas"]:
-            #Instead of refrencing BingCovid, data pertaining to a specific country is refrenced through BingCovidData.State
-            currentState = BingCovidData.State(
+            currentState = BingCovid(
                 confirmed=stateData["totalConfirmed"],
                 deaths=stateData["totalDeaths"],
                 recovered=stateData["totalRecovered"],

--- a/scraping/ScrapeBingCovid/scrape_bing.py
+++ b/scraping/ScrapeBingCovid/scrape_bing.py
@@ -1,14 +1,10 @@
-#!/usr/bin/env python3
-#
-# -*- coding: utf-8 -*-
-#
-# Author(s):
-#   - samueljklee@gmail.com
-#
 
 import sys
 import os
 import logging
+
+from datetime import datetime
+from dateutil import parser
 
 # Connect to db_connector from parent directory
 PARENT_DIR = ".."
@@ -25,15 +21,81 @@ API_URL = "https://bing.com/covid/data"
 # ScrapeRss helper function
 from ScrapeRss.helpers import get_seed_page
 
-# BingCovid
-from ScrapeBingCovid.BingCovid import BingCovid
+#This class acts as the aggregate root
+#It allows entry to specific data points from sublasses within the same domain of BingCovidData
+class BingCovidData: 
+    def __init__(self,  posted_date=datetime.utcnow()):
+    self.posted_date = posted_date
+    self.worlddata = self.WorldData()    
+
+    #This subclass contains enities specifically regarding the whole world
+    class World:
+        def __init__(
+            self,
+            confirmed = None,
+            deaths = None,
+            recovered = None,
+            posted_date=datetime.utcnow()
+        ):
+            self.confirmed = confirmed
+            self.deaths = deaths
+            self.recovered = recovered
+            self.posted_date = posted_date
+
+    #This subclass contains enities specifically regarding specific countries
+    class Country:
+        def __init__(
+            self, 
+            confirmed = None,
+            deaths = None,
+            recovered = None,
+            last_update = None,
+            lat = None,
+            lng = None,
+            country = None,
+            posted_date=datetime.utcnow()
+        ):
+            self.confirmed = confirmed
+            self.deaths = deaths
+            self.recovered = recovered
+            self.last_update = last_update
+            self.lat = lat
+            self.lng = lng
+            self.country = country
+            self.posted_date = posted_date
+
+    #This subclass contains enities specifically regarding specific states
+    class State:
+          def __init__(
+            self, 
+            confirmed = None,
+            deaths = None,
+            recovered = None,
+            last_update = None,
+            lat = None,
+            lng = None,
+            country = None,
+            state = None,
+            posted_date=datetime.utcnow()
+          ):
+            self.confirmed = confirmed
+            self.deaths = deaths
+            self.recovered = recovered
+            self.last_update = last_update
+            self.lat = lat
+            self.lng = lng
+            self.country = country
+            self.state = state
+            self.posted_date = posted_date       
+
 
 if __name__ == "__main__":
     db_bingcovid.connect()
     res = get_seed_page(API_URL).json()
 
-    # whole world
-    wholeWorld = BingCovid(
+    # Whole world
+    #Instead of refrencing BingCovid, data pertaining to the whole world is refrenced through BingCovidData.World
+    wholeWorld = BingCovidData.World(
         confirmed=res["totalConfirmed"],
         deaths=res["totalDeaths"],
         recovered=res["totalRecovered"],
@@ -43,7 +105,8 @@ if __name__ == "__main__":
 
     # Countries
     for countryData in res["areas"]:
-        currentCountry = BingCovid(
+        #Instead of refrencing BingCovid, data pertaining to a specific country is refrenced through BingCovidData.Country
+        currentCountry = BingCovidData.Country(
             confirmed=countryData["totalConfirmed"],
             deaths=countryData["totalDeaths"],
             recovered=countryData["totalRecovered"],
@@ -57,7 +120,8 @@ if __name__ == "__main__":
 
         # States
         for stateData in countryData["areas"]:
-            currentState = BingCovid(
+            #Instead of refrencing BingCovid, data pertaining to a specific country is refrenced through BingCovidData.State
+            currentState = BingCovidData.State(
                 confirmed=stateData["totalConfirmed"],
                 deaths=stateData["totalDeaths"],
                 recovered=stateData["totalRecovered"],

--- a/scraping/scrape_twitter.py
+++ b/scraping/scrape_twitter.py
@@ -6,7 +6,7 @@ import datetime
 # This class acts as an aggregate root
 # It allows entry to the specific data points from objects within the domain of the aggregate (The list of tweets)
 
-Class Tweet:
+class Tweet:
     def __init__(self, username, tweet_id, hashtags, links, timestamp, text):
         self.username = username
         self.tweet_id = tweet_id

--- a/scraping/scrape_twitter.py
+++ b/scraping/scrape_twitter.py
@@ -2,19 +2,40 @@ from twitterscraper import query_tweets
 import json
 import datetime
 
+
+# This class acts as an aggregate root
+# It allows entry to the specific data points from objects within the domain of the aggregate (The list of tweets)
+
+Class Tweet:
+    def __init__(self, username, tweet_id, hashtags, links, timestamp, text):
+        self.username = username
+        self.tweet_id = tweet_id
+        self.hashtags = hashtags
+        self.links = links
+        self.timestamp = timestamp
+        self.text = text
+
+
 if __name__ == '__main__':
     search_query = "WuhanVirus OR 2019nCoV OR Coronavirus OR WuhanCoronavirus OR coronaviruses OR coronavirusoutbreak OR coronavirus OR Covid-19 OR COVID-19 OR ChineseCoronavirus OR Coronaoutbreak"
     filename = "corona_twitter.json"
-    #filename = "{}.json".format(username)
 
     tweets = query_tweets(query=search_query, begindate=datetime.date(2019, 12, 30), enddate=datetime.date(2020, 1, 27))
     print("Found: {} tweets".format(len(tweets)))
 
     j = []
+    # tweet_list is the aggregate which contains a cluster of domain objects (Tweet objects)
+    tweet_list = []
+
     for t in tweets:
         t.timestamp = t.timestamp.isoformat()
+        
+        # Create new Tweet object from current data points and append it to the end of the tweet list
+        tweet_list.append( Tweet(t.username, t.tweet_id, t.hashtags, t.links, t.timestamp, t.text) )
+        
         print("{} {} {} {} {}: {}".format(t.username, t.tweet_id, t.hashtags, t.links, t.timestamp, t.text))
         j.append(t.__dict__)
+
 
     with open(filename, "w") as f:
         f.write(json.dumps(j))


### PR DESCRIPTION
Created an aggregate root Tweet in the file scrape_twitter.py that allows entry to the specific data points from objects within the domain of the aggregate (The list of tweets).

This allows specific tweets to be accessed as well as their data points.

This change also opens the doors for further functionality to be implemented on the tweets such as getting a specific tweet by the ID.

_Further comments_
Please ignore the changes made to scrape_bing.py and show changes from ALL commits
