### PR TITLE
Implement Builder Design Pattern 

### DIFF
--- a/scraping/ScrapeRss/rss_sites.py
+++ b/scraping/ScrapeRss/rss_sites.py
@@ -73,6 +73,79 @@ from ScrapeRss.globals import (
     YEAR_MONTH_DAY_FORMAT,
 )
 
+from abc import ABCMeta, abstractmethod
+
+class INewsSourceBuilder(metaclass = ABCMeta):
+    "The Builder Interface"
+
+@staticmethod
+@abstractmethod
+def build_url():
+    pass
+
+@staticmethod
+@abstractmethod
+def build_title():
+    pass
+
+@staticmethod
+@abstractmethod
+def build_description():
+    pass
+
+@staticmethod
+@abstractmethod
+def build_data_xml():
+    pass
+
+@staticmethod
+@abstractmethod
+def get_news():
+    pass
+    
+class NewsSource(INewsSourceBuilder):
+    "concrete builder"
+
+    def __init__(self): 
+        self.Product = Product()
+    
+    def build_url(self, url):
+        self.url = url
+        return self
+    
+    def build_title(self, title):
+        self.title = title
+        return self
+    
+    def build_description(self, description):
+        self.description = description
+        return self
+    
+    def build_data_xml(self, data_xml):
+        self.data_xml = data_xml
+        return self
+
+    def get_News(self):
+        return self.product
+
+class Product():
+    "the products"
+
+    def __init__(self):
+        self.news = []
+
+class Director:
+    "the director, building a complex representation"
+
+    @staticmethod
+    def construct():
+        "constructs and return final products"
+        return Builder()\
+            .build_url()\
+            .build_title()\
+            .build_description()\
+            .build_data_xml()\
+            .get_news()
 
 NEWS_SOURCES = {
     "de_DE": [
@@ -566,3 +639,5 @@ NEWS_SOURCES = {
         ),
     ],
 }
+
+NEWS = Director.construct()


### PR DESCRIPTION
Apply builder design patter to rss_sites.py so that other files will be able to get info from rss_sites.py easier. 