### PR TITLE
Add select_iterator to db_connector

### DIFF
--- a/scraping/DatabaseConnector/db_connector.py
+++ b/scraping/DatabaseConnector/db_connector.py
@@ -23,6 +23,12 @@ class DatabaseConnector:
         mycursor.execute("SELECT * FROM {}".format(TABLE_NAME))
         return cursor.fetchall()
 
+    def select_iterator(self, offset = 0):
+        cursor = self.mydb.cursor()
+        cursor.execute(f"SELECT * FROM {TABLE_NAME} OFFSET {offset}")
+        for row in cursor:
+            yield row
+
     # NEWS TABLE_SCHEMA
     # ['nid', 'title', 'description', 'author', 'url', 'content', 'urlToImage', 'publishedAt', 'addedOn', 'siteName', 'language', 'countryCode', 'status']
     def insert_news_article(self, data_dict, table_name):


### PR DESCRIPTION
## Description
This pull request adds a new method `select_iterator` to the `DatabaseConnector` class. It purpose is to provide another interface to read data from a table. Previously, the `select` method would return all rows from a table, however this may not always be desirable. I decided to add the iterator behavioural design pattern to provide a new method of interacting with the database.

## Implementation
I implemented the iterator pattern by using the mysql cursor as an iterator as described in the [documentation](https://dev.mysql.com/doc/connector-python/en/connector-python-api-mysqlcursor-fetchone.html). By combining this with Python's `yield` keyword, it creates a method that is able to iterate through the rows one at a time.

Additionally, I added a new optional param `offset`. This parameter will offset where the read begins, and can be used to resume iteration at a later time.

An alternative implementation would be to create a new class that implemented the `__iter__` and `__next__` methods, however I opted to use a python generator instead since it is a lot simpler, and is functionally equivalent in this case. 