### PR TITLE
Convert NEWS_SOURCES to iterator

### DIFF
--- a/scraping/ScrapeRss/rss_sites.py
+++ b/scraping/ScrapeRss/rss_sites.py
@@ -73,7 +73,6 @@ from ScrapeRss.globals import (
     YEAR_MONTH_DAY_FORMAT,
 )
 
-
 NEWS_SOURCES = {
     "de_DE": [
         (
@@ -566,3 +565,20 @@ NEWS_SOURCES = {
         ),
     ],
 }
+
+class NewsSources:
+    def __init__(self, items = NEWS_SOURCES):
+        self.index = 0
+        self._items = items
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            result = self._items[self.index]
+        except IndexError:
+            raise StopIteration
+
+        self.index += 1
+        return result

--- a/scraping/ScrapeRss/scrape_rss.py
+++ b/scraping/ScrapeRss/scrape_rss.py
@@ -75,7 +75,7 @@ db_connector_prodv2.connect()
 
 
 # import all news sources
-from ScrapeRss.rss_sites import NEWS_SOURCES
+from ScrapeRss.rss_sites import NewsSources
 
 # NewsParser
 from ScrapeRss.NewsParser import NewsParser
@@ -349,7 +349,7 @@ if __name__ == "__main__":
         THREADS.append(t)
 
     # place initial seed urls to seed queue to process
-    for locale, list_url_schema in NEWS_SOURCES.items():
+    for locale, list_url_schema in NewsSources():
         logging.debug(
             "locale: {}, Number of websites: {}".format(locale, len(list_url_schema))
         )


### PR DESCRIPTION
## Description
NewsSources is meant to be a collection of news sources that will be scrapped. Having a convenient way to iterate through the collection allows for more flexibility by allowing multiple consumers to have an interface that they can use to iterate.

## Implementation
I implemented an iterator by creating a new class with the `__iter__` and `__next__` keywords. This allows the caller to easily iterate over the collection by initializing a new instance of the class.